### PR TITLE
Certificate params changes

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -18155,6 +18155,8 @@ components:
       - universeDetailSubsets
       type: object
     CertificateParams:
+      description: Certificate Params is used to validate constraints for the custom
+        certificate Data
       example:
         certStart: 6
         customCertInfo:
@@ -18221,10 +18223,6 @@ components:
       - certExpiry
       - certStart
       - certType
-      - customCertInfo
-      - customServerCertData
-      - hcVaultCertParams
-      - keyContent
       - label
       type: object
     CertsRotateParams:

--- a/docs/CertificateInfoApi.md
+++ b/docs/CertificateInfoApi.md
@@ -107,7 +107,7 @@ import (
 func main() {
     cUUID := TODO // string | 
     rUUID := TODO // string | 
-    certificate := *openapiclient.NewCertificateParams("CertContent_example", int64(123), int64(123), "CertType_example", *openapiclient.NewCustomCertInfo("ClientCertPath_example", "ClientKeyPath_example", "NodeCertPath_example", "NodeKeyPath_example", "RootCertPath_example"), *openapiclient.NewCustomServerCertData("ServerCertContent_example", "ServerKeyContent_example"), *openapiclient.NewHashicorpVaultConfigParams("Engine_example", "MountPath_example", "Role_example", "VaultAddr_example"), "KeyContent_example", "Label_example") // CertificateParams | certificate params to edit
+    certificate := *openapiclient.NewCertificateParams("CertContent_example", int64(123), int64(123), "CertType_example", "Label_example") // CertificateParams | certificate params to edit
     request := TODO // interface{} |  (optional)
 
     configuration := openapiclient.NewConfiguration()
@@ -397,7 +397,7 @@ import (
 
 func main() {
     cUUID := TODO // string | 
-    certificate := *openapiclient.NewCertificateParams("CertContent_example", int64(123), int64(123), "CertType_example", *openapiclient.NewCustomCertInfo("ClientCertPath_example", "ClientKeyPath_example", "NodeCertPath_example", "NodeKeyPath_example", "RootCertPath_example"), *openapiclient.NewCustomServerCertData("ServerCertContent_example", "ServerKeyContent_example"), *openapiclient.NewHashicorpVaultConfigParams("Engine_example", "MountPath_example", "Role_example", "VaultAddr_example"), "KeyContent_example", "Label_example") // CertificateParams | certificate params of the backup to be restored
+    certificate := *openapiclient.NewCertificateParams("CertContent_example", int64(123), int64(123), "CertType_example", "Label_example") // CertificateParams | certificate params of the backup to be restored
     request := TODO // interface{} |  (optional)
 
     configuration := openapiclient.NewConfiguration()

--- a/docs/CertificateParams.md
+++ b/docs/CertificateParams.md
@@ -8,17 +8,17 @@ Name | Type | Description | Notes
 **CertExpiry** | **int64** |  | 
 **CertStart** | **int64** |  | 
 **CertType** | **string** |  | 
-**CustomCertInfo** | [**CustomCertInfo**](CustomCertInfo.md) |  | 
-**CustomServerCertData** | [**CustomServerCertData**](CustomServerCertData.md) |  | 
-**HcVaultCertParams** | [**HashicorpVaultConfigParams**](HashicorpVaultConfigParams.md) |  | 
-**KeyContent** | **string** |  | 
+**CustomCertInfo** | Pointer to [**CustomCertInfo**](CustomCertInfo.md) |  | [optional] 
+**CustomServerCertData** | Pointer to [**CustomServerCertData**](CustomServerCertData.md) |  | [optional] 
+**HcVaultCertParams** | Pointer to [**HashicorpVaultConfigParams**](HashicorpVaultConfigParams.md) |  | [optional] 
+**KeyContent** | Pointer to **string** |  | [optional] 
 **Label** | **string** |  | 
 
 ## Methods
 
 ### NewCertificateParams
 
-`func NewCertificateParams(certContent string, certExpiry int64, certStart int64, certType string, customCertInfo CustomCertInfo, customServerCertData CustomServerCertData, hcVaultCertParams HashicorpVaultConfigParams, keyContent string, label string, ) *CertificateParams`
+`func NewCertificateParams(certContent string, certExpiry int64, certStart int64, certType string, label string, ) *CertificateParams`
 
 NewCertificateParams instantiates a new CertificateParams object
 This constructor will assign default values to properties that have it defined,
@@ -132,6 +132,11 @@ and a boolean to check if the value has been set.
 
 SetCustomCertInfo sets CustomCertInfo field to given value.
 
+### HasCustomCertInfo
+
+`func (o *CertificateParams) HasCustomCertInfo() bool`
+
+HasCustomCertInfo returns a boolean if a field has been set.
 
 ### GetCustomServerCertData
 
@@ -152,6 +157,11 @@ and a boolean to check if the value has been set.
 
 SetCustomServerCertData sets CustomServerCertData field to given value.
 
+### HasCustomServerCertData
+
+`func (o *CertificateParams) HasCustomServerCertData() bool`
+
+HasCustomServerCertData returns a boolean if a field has been set.
 
 ### GetHcVaultCertParams
 
@@ -172,6 +182,11 @@ and a boolean to check if the value has been set.
 
 SetHcVaultCertParams sets HcVaultCertParams field to given value.
 
+### HasHcVaultCertParams
+
+`func (o *CertificateParams) HasHcVaultCertParams() bool`
+
+HasHcVaultCertParams returns a boolean if a field has been set.
 
 ### GetKeyContent
 
@@ -192,6 +207,11 @@ and a boolean to check if the value has been set.
 
 SetKeyContent sets KeyContent field to given value.
 
+### HasKeyContent
+
+`func (o *CertificateParams) HasKeyContent() bool`
+
+HasKeyContent returns a boolean if a field has been set.
 
 ### GetLabel
 

--- a/model_certificate_params.go
+++ b/model_certificate_params.go
@@ -14,16 +14,16 @@ import (
 	"encoding/json"
 )
 
-// CertificateParams struct for CertificateParams
+// CertificateParams Certificate Params is used to validate constraints for the custom certificate Data
 type CertificateParams struct {
 	CertContent string `json:"certContent"`
 	CertExpiry int64 `json:"certExpiry"`
 	CertStart int64 `json:"certStart"`
 	CertType string `json:"certType"`
-	CustomCertInfo CustomCertInfo `json:"customCertInfo"`
-	CustomServerCertData CustomServerCertData `json:"customServerCertData"`
-	HcVaultCertParams HashicorpVaultConfigParams `json:"hcVaultCertParams"`
-	KeyContent string `json:"keyContent"`
+	CustomCertInfo *CustomCertInfo `json:"customCertInfo,omitempty"`
+	CustomServerCertData *CustomServerCertData `json:"customServerCertData,omitempty"`
+	HcVaultCertParams *HashicorpVaultConfigParams `json:"hcVaultCertParams,omitempty"`
+	KeyContent *string `json:"keyContent,omitempty"`
 	Label string `json:"label"`
 }
 
@@ -31,16 +31,12 @@ type CertificateParams struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCertificateParams(certContent string, certExpiry int64, certStart int64, certType string, customCertInfo CustomCertInfo, customServerCertData CustomServerCertData, hcVaultCertParams HashicorpVaultConfigParams, keyContent string, label string) *CertificateParams {
+func NewCertificateParams(certContent string, certExpiry int64, certStart int64, certType string, label string) *CertificateParams {
 	this := CertificateParams{}
 	this.CertContent = certContent
 	this.CertExpiry = certExpiry
 	this.CertStart = certStart
 	this.CertType = certType
-	this.CustomCertInfo = customCertInfo
-	this.CustomServerCertData = customServerCertData
-	this.HcVaultCertParams = hcVaultCertParams
-	this.KeyContent = keyContent
 	this.Label = label
 	return &this
 }
@@ -149,100 +145,132 @@ func (o *CertificateParams) SetCertType(v string) {
 	o.CertType = v
 }
 
-// GetCustomCertInfo returns the CustomCertInfo field value
+// GetCustomCertInfo returns the CustomCertInfo field value if set, zero value otherwise.
 func (o *CertificateParams) GetCustomCertInfo() CustomCertInfo {
-	if o == nil {
+	if o == nil || o.CustomCertInfo == nil {
 		var ret CustomCertInfo
 		return ret
 	}
-
-	return o.CustomCertInfo
+	return *o.CustomCertInfo
 }
 
-// GetCustomCertInfoOk returns a tuple with the CustomCertInfo field value
+// GetCustomCertInfoOk returns a tuple with the CustomCertInfo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CertificateParams) GetCustomCertInfoOk() (*CustomCertInfo, bool) {
-	if o == nil  {
+	if o == nil || o.CustomCertInfo == nil {
 		return nil, false
 	}
-	return &o.CustomCertInfo, true
+	return o.CustomCertInfo, true
 }
 
-// SetCustomCertInfo sets field value
+// HasCustomCertInfo returns a boolean if a field has been set.
+func (o *CertificateParams) HasCustomCertInfo() bool {
+	if o != nil && o.CustomCertInfo != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomCertInfo gets a reference to the given CustomCertInfo and assigns it to the CustomCertInfo field.
 func (o *CertificateParams) SetCustomCertInfo(v CustomCertInfo) {
-	o.CustomCertInfo = v
+	o.CustomCertInfo = &v
 }
 
-// GetCustomServerCertData returns the CustomServerCertData field value
+// GetCustomServerCertData returns the CustomServerCertData field value if set, zero value otherwise.
 func (o *CertificateParams) GetCustomServerCertData() CustomServerCertData {
-	if o == nil {
+	if o == nil || o.CustomServerCertData == nil {
 		var ret CustomServerCertData
 		return ret
 	}
-
-	return o.CustomServerCertData
+	return *o.CustomServerCertData
 }
 
-// GetCustomServerCertDataOk returns a tuple with the CustomServerCertData field value
+// GetCustomServerCertDataOk returns a tuple with the CustomServerCertData field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CertificateParams) GetCustomServerCertDataOk() (*CustomServerCertData, bool) {
-	if o == nil  {
+	if o == nil || o.CustomServerCertData == nil {
 		return nil, false
 	}
-	return &o.CustomServerCertData, true
+	return o.CustomServerCertData, true
 }
 
-// SetCustomServerCertData sets field value
+// HasCustomServerCertData returns a boolean if a field has been set.
+func (o *CertificateParams) HasCustomServerCertData() bool {
+	if o != nil && o.CustomServerCertData != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomServerCertData gets a reference to the given CustomServerCertData and assigns it to the CustomServerCertData field.
 func (o *CertificateParams) SetCustomServerCertData(v CustomServerCertData) {
-	o.CustomServerCertData = v
+	o.CustomServerCertData = &v
 }
 
-// GetHcVaultCertParams returns the HcVaultCertParams field value
+// GetHcVaultCertParams returns the HcVaultCertParams field value if set, zero value otherwise.
 func (o *CertificateParams) GetHcVaultCertParams() HashicorpVaultConfigParams {
-	if o == nil {
+	if o == nil || o.HcVaultCertParams == nil {
 		var ret HashicorpVaultConfigParams
 		return ret
 	}
-
-	return o.HcVaultCertParams
+	return *o.HcVaultCertParams
 }
 
-// GetHcVaultCertParamsOk returns a tuple with the HcVaultCertParams field value
+// GetHcVaultCertParamsOk returns a tuple with the HcVaultCertParams field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CertificateParams) GetHcVaultCertParamsOk() (*HashicorpVaultConfigParams, bool) {
-	if o == nil  {
+	if o == nil || o.HcVaultCertParams == nil {
 		return nil, false
 	}
-	return &o.HcVaultCertParams, true
+	return o.HcVaultCertParams, true
 }
 
-// SetHcVaultCertParams sets field value
+// HasHcVaultCertParams returns a boolean if a field has been set.
+func (o *CertificateParams) HasHcVaultCertParams() bool {
+	if o != nil && o.HcVaultCertParams != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHcVaultCertParams gets a reference to the given HashicorpVaultConfigParams and assigns it to the HcVaultCertParams field.
 func (o *CertificateParams) SetHcVaultCertParams(v HashicorpVaultConfigParams) {
-	o.HcVaultCertParams = v
+	o.HcVaultCertParams = &v
 }
 
-// GetKeyContent returns the KeyContent field value
+// GetKeyContent returns the KeyContent field value if set, zero value otherwise.
 func (o *CertificateParams) GetKeyContent() string {
-	if o == nil {
+	if o == nil || o.KeyContent == nil {
 		var ret string
 		return ret
 	}
-
-	return o.KeyContent
+	return *o.KeyContent
 }
 
-// GetKeyContentOk returns a tuple with the KeyContent field value
+// GetKeyContentOk returns a tuple with the KeyContent field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CertificateParams) GetKeyContentOk() (*string, bool) {
-	if o == nil  {
+	if o == nil || o.KeyContent == nil {
 		return nil, false
 	}
-	return &o.KeyContent, true
+	return o.KeyContent, true
 }
 
-// SetKeyContent sets field value
+// HasKeyContent returns a boolean if a field has been set.
+func (o *CertificateParams) HasKeyContent() bool {
+	if o != nil && o.KeyContent != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetKeyContent gets a reference to the given string and assigns it to the KeyContent field.
 func (o *CertificateParams) SetKeyContent(v string) {
-	o.KeyContent = v
+	o.KeyContent = &v
 }
 
 // GetLabel returns the Label field value
@@ -283,16 +311,16 @@ func (o CertificateParams) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["certType"] = o.CertType
 	}
-	if true {
+	if o.CustomCertInfo != nil {
 		toSerialize["customCertInfo"] = o.CustomCertInfo
 	}
-	if true {
+	if o.CustomServerCertData != nil {
 		toSerialize["customServerCertData"] = o.CustomServerCertData
 	}
-	if true {
+	if o.HcVaultCertParams != nil {
 		toSerialize["hcVaultCertParams"] = o.HcVaultCertParams
 	}
-	if true {
+	if o.KeyContent != nil {
 		toSerialize["keyContent"] = o.KeyContent
 	}
 	if true {


### PR DESCRIPTION
Marking `keyContent` and other parameters as optional in Certificate parameters