### PR TITLE
New release management API changes to return type

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11038,7 +11038,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/YBPSuccess'
+                $ref: '#/components/schemas/YBPCreateSuccess'
           description: successful operation
       security:
       - apiKeyAuth: []
@@ -11100,8 +11100,11 @@ paths:
         schema:
           exampleSetFlag: false
       responses:
-        default:
-          content: {}
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/YBPCreateSuccess'
           description: successful operation
       security:
       - apiKeyAuth: []

--- a/api_extract_metadata_from_remote_tarball.go
+++ b/api_extract_metadata_from_remote_tarball.go
@@ -44,7 +44,7 @@ func (r ExtractMetadataFromRemoteTarballApiApiExtractMetadataRequest) Request(re
 	return r
 }
 
-func (r ExtractMetadataFromRemoteTarballApiApiExtractMetadataRequest) Execute() (YBPSuccess, *_nethttp.Response, error) {
+func (r ExtractMetadataFromRemoteTarballApiApiExtractMetadataRequest) Execute() (YBPCreateSuccess, *_nethttp.Response, error) {
 	return r.ApiService.ExtractMetadataExecute(r)
 }
 
@@ -65,16 +65,16 @@ func (a *ExtractMetadataFromRemoteTarballApiService) ExtractMetadata(ctx _contex
 
 /*
  * Execute executes the request
- * @return YBPSuccess
+ * @return YBPCreateSuccess
  */
-func (a *ExtractMetadataFromRemoteTarballApiService) ExtractMetadataExecute(r ExtractMetadataFromRemoteTarballApiApiExtractMetadataRequest) (YBPSuccess, *_nethttp.Response, error) {
+func (a *ExtractMetadataFromRemoteTarballApiService) ExtractMetadataExecute(r ExtractMetadataFromRemoteTarballApiApiExtractMetadataRequest) (YBPCreateSuccess, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		localVarReturnValue  YBPSuccess
+		localVarReturnValue  YBPCreateSuccess
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ExtractMetadataFromRemoteTarballApiService.ExtractMetadata")

--- a/api_upload_release_packages.go
+++ b/api_upload_release_packages.go
@@ -171,7 +171,7 @@ func (r UploadReleasePackagesApiApiUploadReleaseRequest) Request(request interfa
 	return r
 }
 
-func (r UploadReleasePackagesApiApiUploadReleaseRequest) Execute() (*_nethttp.Response, error) {
+func (r UploadReleasePackagesApiApiUploadReleaseRequest) Execute() (YBPCreateSuccess, *_nethttp.Response, error) {
 	return r.ApiService.UploadReleaseExecute(r)
 }
 
@@ -192,19 +192,21 @@ func (a *UploadReleasePackagesApiService) UploadRelease(ctx _context.Context, cU
 
 /*
  * Execute executes the request
+ * @return YBPCreateSuccess
  */
-func (a *UploadReleasePackagesApiService) UploadReleaseExecute(r UploadReleasePackagesApiApiUploadReleaseRequest) (*_nethttp.Response, error) {
+func (a *UploadReleasePackagesApiService) UploadReleaseExecute(r UploadReleasePackagesApiApiUploadReleaseRequest) (YBPCreateSuccess, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		localVarReturnValue  YBPCreateSuccess
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UploadReleasePackagesApiService.UploadRelease")
 	if err != nil {
-		return nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/api/v1/customers/{cUUID}/ybdb_release/upload"
@@ -227,7 +229,7 @@ func (a *UploadReleasePackagesApiService) UploadReleaseExecute(r UploadReleasePa
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{}
+	localVarHTTPHeaderAccepts := []string{"application/json"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -250,19 +252,19 @@ func (a *UploadReleasePackagesApiService) UploadReleaseExecute(r UploadReleasePa
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return nil, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarHTTPResponse, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarHTTPResponse, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -270,8 +272,17 @@ func (a *UploadReleasePackagesApiService) UploadReleaseExecute(r UploadReleasePa
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
-		return localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, nil
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/docs/ExtractMetadataFromRemoteTarballApi.md
+++ b/docs/ExtractMetadataFromRemoteTarballApi.md
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 
 ## ExtractMetadata
 
-> YBPSuccess ExtractMetadata(ctx, cUUID).ReleaseURL(releaseURL).Request(request).Execute()
+> YBPCreateSuccess ExtractMetadata(ctx, cUUID).ReleaseURL(releaseURL).Request(request).Execute()
 
 helper to extract release metadata from a remote tarball
 
@@ -41,7 +41,7 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `ExtractMetadataFromRemoteTarballApi.ExtractMetadata``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
-    // response from `ExtractMetadata`: YBPSuccess
+    // response from `ExtractMetadata`: YBPCreateSuccess
     fmt.Fprintf(os.Stdout, "Response from `ExtractMetadataFromRemoteTarballApi.ExtractMetadata`: %v\n", resp)
 }
 ```
@@ -67,7 +67,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**YBPSuccess**](YBPSuccess.md)
+[**YBPCreateSuccess**](YBPCreateSuccess.md)
 
 ### Authorization
 

--- a/docs/UploadReleasePackagesApi.md
+++ b/docs/UploadReleasePackagesApi.md
@@ -86,7 +86,7 @@ Name | Type | Description  | Notes
 
 ## UploadRelease
 
-> UploadRelease(ctx, cUUID).Request(request).Execute()
+> YBPCreateSuccess UploadRelease(ctx, cUUID).Request(request).Execute()
 
 upload a release tgz
 
@@ -115,6 +115,8 @@ func main() {
         fmt.Fprintf(os.Stderr, "Error when calling `UploadReleasePackagesApi.UploadRelease``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
+    // response from `UploadRelease`: YBPCreateSuccess
+    fmt.Fprintf(os.Stdout, "Response from `UploadReleasePackagesApi.UploadRelease`: %v\n", resp)
 }
 ```
 
@@ -138,7 +140,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+[**YBPCreateSuccess**](YBPCreateSuccess.md)
 
 ### Authorization
 
@@ -147,7 +149,7 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: Not defined
+- **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)


### PR DESCRIPTION
The return type defined in the API model parameters do not match the return type of the API. Making this change to ensure the correct API output is provided